### PR TITLE
fix: if default is set, then this field is enforced

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,30 +63,13 @@ defmodule User do
 
   @type t() :: %__MODULE__{
     id: pos_integer() | nil,
-    # Note: The 'name' can be nil, even though it has a default value.
-    name: String.t() | nil,
+    # Note: The 'name' can not be nil, for it has a default value.
+    name: String.t(),
     age: non_neg_integer()
   }
 end
 ```
 Check `TypedStructor.typed_structor/2` and `TypedStructor.field/3` for more information.
-
-> #### `:enforce` and `:default` option  {: .warning}
-> Note that the `default` option does not affect the `enforce` option.
-> If you want to enforce a field, you should explicitly set the `enforce` option to `true`.
->
-> Consider the following example, `nil` is a valid value for the `:foo` field.
->
-> ```elixir
-> defmodule Settings do
->   @enforce_keys [:foo]
->   defstruct [foo: :bar]
-> end
-> 
-> %Settings{} # => ** (ArgumentError) the following keys must also be given when building struct Settings: [:foo]
-> # `nil` is a valid value for the `:foo` field
-> %Settings{foo: nil} # => %Settings{foo: nil}
-> ```
 
 ### Options
 
@@ -171,7 +154,7 @@ defmodule User do
   typed_structor define_struct: false do
     field :id, pos_integer()
     field :name, String.t()
-    field :age, non_neg_integer(), default: 0 # default value is useless in this case
+    field :age, non_neg_integer(), default: 0
   end
 
   schema "users" do

--- a/lib/typed_structor.ex
+++ b/lib/typed_structor.ex
@@ -221,7 +221,7 @@ defmodule TypedStructor do
             name = Keyword.fetch!(field, :name)
             default = Keyword.get(field, :default)
 
-            if Keyword.get(field, :enforce, false) do
+            if TypedStructor.__is_enforced__?(field) do
               {{name, default}, [name | acc]}
             else
               {{name, default}, acc}
@@ -251,7 +251,7 @@ defmodule TypedStructor do
           name = Keyword.fetch!(field, :name)
           type = Keyword.fetch!(field, :type)
 
-          if Keyword.get(field, :enforce, false) do
+          if TypedStructor.__is_enforced__?(field) do
             [{name, type} | acc]
           else
             [{name, quote(do: unquote(type) | nil)} | acc]
@@ -288,7 +288,7 @@ defmodule TypedStructor do
 
       enforced_fields =
         @__ts_definition__.fields
-        |> Stream.filter(&Keyword.get(&1, :enforce, false))
+        |> Stream.filter(&TypedStructor.__is_enforced__?/1)
         |> Stream.map(&Keyword.fetch!(&1, :name))
         |> Enum.to_list()
 
@@ -346,5 +346,9 @@ defmodule TypedStructor do
         end
       )
     end
+  end
+
+  def __is_enforced__?(field) do
+    Keyword.get(field, :enforce, false) or Keyword.has_key?(field, :default)
   end
 end

--- a/test/reflection_test.exs
+++ b/test/reflection_test.exs
@@ -8,7 +8,7 @@ defmodule ReflectionTest do
       parameter :age
 
       field :name, String.t(), enforce: true
-      field :age, age
+      field :age, age, default: 20
     end
   end
 
@@ -28,7 +28,7 @@ defmodule ReflectionTest do
     assert [:age] === Struct.__typed_structor__(:parameters)
     assert [] === MyModule.Struct.__typed_structor__(:parameters)
 
-    assert [:name] === Struct.__typed_structor__(:enforced_fields)
+    assert [:name, :age] === Struct.__typed_structor__(:enforced_fields)
     assert [:name, :age] === MyModule.Struct.__typed_structor__(:enforced_fields)
 
     assert "String.t()" === Macro.to_string(Struct.__typed_structor__(:type, :name))
@@ -47,7 +47,7 @@ defmodule ReflectionTest do
 
     assert [enforce: true, name: :name, type: type] = Struct.__typed_structor__(:field, :name)
     assert "String.t()" === Macro.to_string(type)
-    assert [name: :age, type: type] = Struct.__typed_structor__(:field, :age)
+    assert [default: 20, name: :age, type: type] = Struct.__typed_structor__(:field, :age)
     assert "age" === Macro.to_string(type)
   end
 end

--- a/test/typed_structor_test.exs
+++ b/test/typed_structor_test.exs
@@ -256,14 +256,27 @@ defmodule TypedStructorTest do
 
   describe "default option on the field" do
     test "generates struct with default values" do
-      deftmpmodule do
-        use TypedStructor
+      expected_bytecode =
+        test_module do
+          @type t() :: %TestModule{
+                  name: String.t(),
+                  age: integer() | nil
+                }
 
-        typed_structor do
-          field :name, String.t(), default: "Phil"
-          field :age, integer()
+          defstruct [:age, :name]
         end
-      end
+
+      expected_types = types(expected_bytecode)
+
+      bytecode =
+        deftmpmodule do
+          use TypedStructor
+
+          typed_structor do
+            field :name, String.t(), default: "Phil"
+            field :age, integer()
+          end
+        end
 
       assert match?(
                %{
@@ -273,6 +286,8 @@ defmodule TypedStructorTest do
                },
                struct(TestModule)
              )
+
+      assert expected_types === types(bytecode)
     end
   end
 


### PR DESCRIPTION
This change aligns TypedStructor with TypedStruct.
