### PR TITLE
[WIP] [Idea] Assoc macro

### DIFF
--- a/lib/typed_structor.ex
+++ b/lib/typed_structor.ex
@@ -92,7 +92,7 @@ defmodule TypedStructor do
       # create a lexical scope
       try do
         import TypedStructor,
-          only: [field: 2, field: 3, parameter: 1, parameter: 2, plugin: 1, plugin: 2]
+          only: [assoc: 2, field: 2, field: 3, parameter: 1, parameter: 2, plugin: 1, plugin: 2]
 
         unquote(register_global_plugins())
 
@@ -197,6 +197,16 @@ defmodule TypedStructor do
       @__ts_struct_fields__ Keyword.merge(@__ts_options__, unquote(options))
     end
   end
+
+  defmacro assoc(name, type, options \\ []) do
+    type = quote(do: unquote(type) | Ecto.Association.NotLoaded.t())
+    options = Keyword.merge(options, name: name, type: Macro.escape(type))
+
+    quote do
+      @__ts_struct_fields__ Keyword.merge(@__ts_options__, unquote(options))
+    end
+  end
+
 
   @doc """
   Defines a type parameter in a `typed_structor/2`.

--- a/lib/typed_structor.ex
+++ b/lib/typed_structor.ex
@@ -207,7 +207,6 @@ defmodule TypedStructor do
     end
   end
 
-
   @doc """
   Defines a type parameter in a `typed_structor/2`.
 

--- a/test/typed_structor_test.exs
+++ b/test/typed_structor_test.exs
@@ -5,7 +5,7 @@ defmodule TypedStructorTest do
 
   @tag :tmp_dir
   test "generates the struct and the type", ctx do
-    {expected_types, expected_sub_types}  =
+    {expected_types, expected_sub_types} =
       with_tmpmodule Struct, ctx do
         @type t() :: %__MODULE__{
                 age: integer() | nil,
@@ -38,7 +38,7 @@ defmodule TypedStructorTest do
           use TypedStructor
 
           typed_structor do
-            assoc :parent, Struct.t()
+            assoc(:parent, Struct.t())
           end
         end
       after

--- a/test/typed_structor_test.exs
+++ b/test/typed_structor_test.exs
@@ -16,7 +16,7 @@ defmodule TypedStructorTest do
 
         defmodule SubStruct do
           @type t() :: %__MODULE__{
-                  parent: Struct.t() | Ecto.Assocation.NotLoaded.t() | nil
+                  parent: (Struct.t() | Ecto.Association.NotLoaded.t()) | nil
                 }
 
           defstruct [:parent]
@@ -38,7 +38,7 @@ defmodule TypedStructorTest do
           use TypedStructor
 
           typed_structor do
-            field :parent, Struct.t()
+            assoc :parent, Struct.t()
           end
         end
       after

--- a/test/typed_structor_test.exs
+++ b/test/typed_structor_test.exs
@@ -16,10 +16,11 @@ defmodule TypedStructorTest do
 
         defmodule SubStruct do
           @type t() :: %__MODULE__{
-                  parent: (Struct.t() | Ecto.Association.NotLoaded.t()) | nil
+                  parent: (Struct.t() | Ecto.Association.NotLoaded.t()) | nil,
+                  parents: ([Struct.t()] | Ecto.Association.NotLoaded.t()) | nil
                 }
 
-          defstruct [:parent]
+          defstruct [:parent, :parents]
         end
       after
         {fetch_types!(Struct), fetch_types!(Struct.SubStruct)}
@@ -39,6 +40,7 @@ defmodule TypedStructorTest do
 
           typed_structor do
             assoc(:parent, Struct.t())
+            assoc(:parents, [Struct.t()])
           end
         end
       after


### PR DESCRIPTION
This demonstrates the idea of an `assoc` macro which removes the need to specify ` | Ecto.Association.NotLoaded.t()` on every single "association" field.